### PR TITLE
Api review

### DIFF
--- a/src/Primitive.Text.Indexing/Documents/Sources/FileSystemDocumentSource.cs
+++ b/src/Primitive.Text.Indexing/Documents/Sources/FileSystemDocumentSource.cs
@@ -60,23 +60,24 @@ namespace Primitive.Text.Documents.Sources
 
 
         /// <summary>
-        ///  Extracts words to index from the <paramref name="document"/> with the specified <paramref name="textParser"/>
+        ///  Reads the <paramref name="document"/> with the specified progressive <paramref name="documentReader"/>
         /// </summary>
+        /// <typeparam name="T">Type of data elements being read from the document</typeparam>
         /// <param name="document">The document from this source</param>
-        /// <param name="textParser">The parser to be used to extract words from the document stream</param>
+        /// <param name="documentReader">
+        ///  A function, that given the document <see cref="TextReader"/> extracts the elements of the <typeparamref name="T"/> type from it.
+        /// </param>
         /// <returns>
-        /// Returns an observable sequence of document words, that being subscribed to
-        /// pushes all words from the document and then completes. This sequence also complete with fail, if there was
-        /// an error opening or reading the document.
+        ///  Returns an observable sequence returned by <paramref name="documentReader"/>.
         /// </returns>
         /// <remarks>
         /// This override adds retry semantics in case of document file is locked or cannot be opened due to some other
         /// <see cref="IOException"/>
         /// </remarks>
-        public override IObservable<string> ExtractDocumentWords(DocumentInfo document, ITextParser textParser)
+        public override IObservable<T> ReadDocumentText<T>(DocumentInfo document, Func<TextReader, IObservable<T>> documentReader)
         {
             return RetryOn(
-                base.ExtractDocumentWords(document, textParser),
+                base.ReadDocumentText(document, documentReader),
                 shouldRetry: e => e is IOException, retryTimes: 3, retryDelay: TimeSpan.FromSeconds(1));
         }
 

--- a/src/Primitive.Text.Indexing/Documents/Sources/IDocumentSource.cs
+++ b/src/Primitive.Text.Indexing/Documents/Sources/IDocumentSource.cs
@@ -30,15 +30,20 @@ namespace Primitive.Text.Documents.Sources
         IObservable<DocumentInfo> WatchForChangedDocuments();
 
         /// <summary>
-        ///  Extracts words to index from the <paramref name="document"/> with the specified <paramref name="textParser"/>
+        ///  Reads the <paramref name="document"/> with the specified progressive <paramref name="documentReader"/>
         /// </summary>
+        /// <typeparam name="T">Type of data elements being read from the document</typeparam>
         /// <param name="document">The document from this source</param>
-        /// <param name="textParser">The parser to be used to extract words from the document stream</param>
+        /// <param name="documentReader">
+        ///  A function, that given the document <see cref="TextReader"/> extracts the elements of the <typeparamref name="T"/> type from it.
+        /// </param>
         /// <returns>
-        /// Returns an observable sequence of document words, that being subscribed to
-        /// pushes all words from the document and then completes. 
-        /// This sequence can also complete with fail, if there was  an error opening or reading the document.
+        ///  Returns an empty sequence if the document is not found.
+        ///  Returns a failed empty sequence if the document cannot be opened.
+        ///  Returns an observable sequence returned by <paramref name="documentReader"/>, that being subscribed to
+        ///  pushes all the extracted data elements from the document and then completes.
+        ///  This sequence can also complete with fail, if there was an error reading the document.
         /// </returns>
-        IObservable<string> ExtractDocumentWords([NotNull] DocumentInfo document, [NotNull] ITextParser textParser);
+        IObservable<T> ReadDocumentText<T>([NotNull] DocumentInfo document, [NotNull] Func<TextReader, IObservable<T>> documentReader);
     }
 }

--- a/src/Primitive.Text.Indexing/Indexing/IIndex.cs
+++ b/src/Primitive.Text.Indexing/Indexing/IIndex.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Primitive.Text.Documents;
 
@@ -100,17 +101,24 @@ namespace Primitive.Text.Indexing
         /// </summary>
         /// <param name="document">Document to include in index</param>
         /// <param name="indexWords">Words to index document by</param>
+        /// <returns>
+        ///  Task that completes when document merging is completed
+        /// </returns>
         /// <remarks>
         /// <para>
         ///  Merge should be implemented as an atomic operation: queries and snapshot operations 
         ///  either will see index before the merge or after the merge.
         /// </para>
         /// <para>
+        ///  Merge can execute itself synchronously and return already completed task if an index implementation
+        ///  doesn't support effective merge parallelization.
+        /// </para>
+        /// <para>
         /// When the <paramref name="document"/> is already included in this index, 
         /// its old index words are removed from index before merging new index words.
         /// </para>
         /// </remarks>
-        void Merge([NotNull] DocumentInfo document, [NotNull] IEnumerable<string> indexWords);
+        Task Merge([NotNull] DocumentInfo document, [NotNull] IEnumerable<string> indexWords);
 
         /// <summary>
         ///  Removes from the index all documents matching the specified <paramref name="predicate"/>

--- a/src/Primitive.Text.Indexing/Indexing/Indexer.cs
+++ b/src/Primitive.Text.Indexing/Indexing/Indexer.cs
@@ -205,7 +205,7 @@ namespace Primitive.Text.Indexing
                     .SelectMany(files => files)
                     .SelectMany(IndexDocument)
                     .Do(_ => OnParsingStarted())
-                    .Select(d => Observable.FromAsync(() => Task.Run(() => Index.Merge(d.Document, d.IndexWords))))
+                    .Select(d => Observable.FromAsync(() => Index.Merge(d.Document, d.IndexWords)))
                     .Merge(maxConcurrentIndexing)
                     .Do(_ => DocumentsParsed += 1, ex => { this.Error = ex; OnStateChanged(); })
                     .Throttle(TimeSpan.FromSeconds(1))

--- a/src/Primitive.Text.Indexing/Indexing/Indexer.cs
+++ b/src/Primitive.Text.Indexing/Indexing/Indexer.cs
@@ -36,7 +36,7 @@ namespace Primitive.Text.Indexing
         private readonly Subject<Tuple<DocumentInfo, Exception>> indexingErrors = new Subject<Tuple<DocumentInfo, Exception>>();
 
         private readonly StringComparisonComparer wordComparer;
-
+        private readonly object lockObject = new object();
 
         /// <summary>
         ///  Creates an instance of <see cref="Indexer"/> that will be indexing documents from 
@@ -186,7 +186,7 @@ namespace Primitive.Text.Indexing
         /// </remarks>
         public void StartIndexing()
         {
-            lock (this)
+            lock (lockObject)
             {
                 if (subscription != null) return;
 
@@ -221,7 +221,7 @@ namespace Primitive.Text.Indexing
         {
             
             // Stop producing indexed documents
-            lock (this)
+            lock (lockObject)
             {
                 if (subscription != null)
                     subscription.Dispose();

--- a/src/Primitive.Text.Indexing/Indexing/Indexer.cs
+++ b/src/Primitive.Text.Indexing/Indexing/Indexer.cs
@@ -3,12 +3,12 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Primitive.Text.Documents;
 using Primitive.Text.Documents.Sources;
@@ -262,7 +262,8 @@ namespace Primitive.Text.Indexing
                         indexingErrors.OnNext(Tuple.Create(documentInfo, e));
                         // consider there is no document to index if words can't be extracted from it.
                         return Observable.Empty<IndexedDocument>();
-                    });
+                    })
+                    .SubscribeOn(Scheduler.Default);
         }
 
 

--- a/src/Primitive.Text.Indexing/Indexing/IndexerSet.cs
+++ b/src/Primitive.Text.Indexing/Indexing/IndexerSet.cs
@@ -45,6 +45,7 @@ namespace Primitive.Text.Indexing
 
 
         private volatile IImmutableList<Indexer> indexers;
+        private readonly object lockObject = new object();
 
 
         private IndexerSet([NotNull] IIndex index, [NotNull] ITextParser defaultTextParser)
@@ -95,7 +96,7 @@ namespace Primitive.Text.Indexing
             if (ContainsSource(indexer.Source))
                 throw new ArgumentException("Source is already included in this IndexerSet", "indexer");
 
-            lock (this)
+            lock (lockObject)
                 indexers = indexers.Add(indexer);
 
             return indexer;
@@ -122,7 +123,7 @@ namespace Primitive.Text.Indexing
 
             var indexer = new Indexer(Index, source, textParser ?? DefaultTextParser);
 
-            lock (this)
+            lock (lockObject)
                 indexers = indexers.Add(indexer);
 
             if (autoStartIndexing)
@@ -149,7 +150,7 @@ namespace Primitive.Text.Indexing
             if (indexer == null)
                 throw new ArgumentNullException("indexer");
 
-            lock (this)
+            lock (lockObject)
             {
                 var newSources = indexers.Remove(indexer);
                 if (indexers == newSources)

--- a/src/Primitive.Text.Indexing/Indexing/Indexes/ImmutableIndex.cs
+++ b/src/Primitive.Text.Indexing/Indexing/Indexes/ImmutableIndex.cs
@@ -173,9 +173,12 @@ namespace Primitive.Text.Indexing
             lock (lockIndex)
             {
                 var oldDocuments = state.documents;
-                var newDocuments = oldDocuments.Except(oldDocuments.Where(predicate));
-                if (newDocuments == oldDocuments)
+                var allDocumentsToRemove = new HashSet<DocumentInfo>(oldDocuments.Where(predicate));
+                if (!allDocumentsToRemove.Any())
                     return;
+                var newDocuments = oldDocuments.Except(allDocumentsToRemove);
+
+                predicate = allDocumentsToRemove.Contains;
 
                 var oldIndex = state.wordIndex;
                 var newIndex = new InternalSortedList<string, IImmutableSet<DocumentInfo>>(this.wordComparer, oldIndex.Count);

--- a/src/Primitive.Text.Indexing/Indexing/Indexes/ImmutableIndex.cs
+++ b/src/Primitive.Text.Indexing/Indexing/Indexes/ImmutableIndex.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Primitive.Text.Documents;
 using Primitive.Text.Indexing.Internal;
@@ -94,7 +95,7 @@ namespace Primitive.Text.Indexing
             return new ImmutableIndex(state.wordIndex, state.documents);
         }
 
-        public void Merge([NotNull] DocumentInfo document, [NotNull] IEnumerable<string> indexWords)
+        public Task Merge([NotNull] DocumentInfo document, [NotNull] IEnumerable<string> indexWords)
         {
             if (document == null) throw new ArgumentNullException("document");
             if (indexWords == null) throw new ArgumentNullException("indexWords");
@@ -108,7 +109,8 @@ namespace Primitive.Text.Indexing
                 var oldDocuments = state.documents;
                 var newDocuments = hasWords ? oldDocuments.Add(document) : oldDocuments.Remove(document);
                 bool isNewDocument = hasWords == (newDocuments != oldDocuments);
-                if (isNewDocument && !hasWords) return;
+                if (isNewDocument && !hasWords) 
+                    return CompletedTask.Instance;
 
                 var oldIndex = state.wordIndex;
                 var newIndex = new InternalSortedList<string, IImmutableSet<DocumentInfo>>(this.wordComparer, oldIndex.Count + sourceWords.Count);
@@ -164,6 +166,7 @@ namespace Primitive.Text.Indexing
                 }
                 this.state = new State(newIndex, newDocuments);
             }
+            return CompletedTask.Instance;
         }
 
         public void RemoveDocumentsMatching([NotNull] Func<DocumentInfo, bool> predicate)

--- a/src/Primitive.Text.Indexing/Indexing/Indexes/LockingIndex.cs
+++ b/src/Primitive.Text.Indexing/Indexing/Indexes/LockingIndex.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Primitive.Text.Documents;
 using Primitive.Text.Indexing.Internal;
@@ -95,7 +96,7 @@ namespace Primitive.Text.Indexing
             return snapshot;
         }
 
-        public void Merge(DocumentInfo document, IEnumerable<string> indexWords)
+        public Task Merge(DocumentInfo document, IEnumerable<string> indexWords)
         {
             if (document == null) throw new ArgumentNullException("document");
             if (indexWords == null) throw new ArgumentNullException("indexWords");
@@ -107,7 +108,8 @@ namespace Primitive.Text.Indexing
             using (locking.InWriteLock())
             {
                 bool isNewDocument = hasWords ? allDocuments.Add(document) : !allDocuments.Remove(document);
-                if (isNewDocument && !hasWords) return;
+                if (isNewDocument && !hasWords)
+                    return CompletedTask.Instance;
 
                 int idxSource = 0;
                 int idxTarget = 0;
@@ -158,6 +160,7 @@ namespace Primitive.Text.Indexing
                     idxTarget += 1;
                 }
             }
+            return CompletedTask.Instance;
         }
 
         public void RemoveDocumentsMatching([NotNull] Func<DocumentInfo, bool> predicate)

--- a/src/Primitive.Text.Indexing/Indexing/Indexes/LockingIndex.cs
+++ b/src/Primitive.Text.Indexing/Indexing/Indexes/LockingIndex.cs
@@ -166,11 +166,14 @@ namespace Primitive.Text.Indexing
 
             using (locking.InWriteLock())
             {
-                var valuesToRemove = allDocuments.Where(predicate).ToList();
-                if (!valuesToRemove.Any())
+                var allDocumentsToRemove = new HashSet<DocumentInfo>(allDocuments.Where(predicate));
+                if (!allDocumentsToRemove.Any())
                     return;
-                allDocuments.ExceptWith(valuesToRemove);
-                valuesToRemove = new List<DocumentInfo>();
+                allDocuments.ExceptWith(allDocumentsToRemove);
+
+                predicate = allDocumentsToRemove.Contains;
+
+                var valuesToRemove = new List<DocumentInfo>();
 
                 for (int i = wordIndex.Count - 1; i >= 0; i--)
                 {

--- a/src/Primitive.Text.Indexing/Indexing/Internal/CompletedTask.cs
+++ b/src/Primitive.Text.Indexing/Indexing/Internal/CompletedTask.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Primitive.Text.Indexing.Internal
+{
+    internal static class CompletedTask
+    {
+        public static readonly Task Instance = Task.FromResult<object>(null);
+    }
+}

--- a/src/Primitive.Text.Indexing/Primitive.Text.Indexing.csproj
+++ b/src/Primitive.Text.Indexing/Primitive.Text.Indexing.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Indexing\IndexerCreationOptions.cs" />
     <Compile Include="Indexing\Indexes\ImmutableIndex.cs" />
     <Compile Include="Indexing\Indexes\LockingIndex.cs" />
+    <Compile Include="Indexing\Internal\CompletedTask.cs" />
     <Compile Include="Indexing\Internal\InternalSortedList.cs" />
     <Compile Include="Indexing\Internal\LockingStrategy.cs" />
     <Compile Include="Indexing\Internal\StringComparisonComparer.cs" />

--- a/tests/Primitive.Text.Indexing.Tests/Documents/Sources/TestDocumentSource.cs
+++ b/tests/Primitive.Text.Indexing.Tests/Documents/Sources/TestDocumentSource.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Linq;
 using System.Text;
-using Primitive.Text.Parsers;
 
 namespace Primitive.Text.Documents.Sources
 {
@@ -21,7 +20,7 @@ namespace Primitive.Text.Documents.Sources
             throw new NotImplementedException();
         }
 
-        public IObservable<string> ExtractDocumentWords(DocumentInfo document, ITextParser textParser)
+        public IObservable<T> ReadDocumentText<T>(DocumentInfo document, Func<TextReader, IObservable<T>> documentReader)
         {
             throw new NotImplementedException();
         }

--- a/tests/Primitive.Text.Indexing.Tests/Indexing/IndexTests.cs
+++ b/tests/Primitive.Text.Indexing.Tests/Indexing/IndexTests.cs
@@ -35,7 +35,7 @@ namespace Primitive.Text.Indexing
             var document = new DocumentInfo("id1", TestDocumentSource.Instance);
             var words = new[] {"cat", "category"};
 
-            index.Merge(document, words);
+            index.Merge(document, words).Wait();
 
             foreach (var word in words)
             {
@@ -53,7 +53,7 @@ namespace Primitive.Text.Indexing
             }
             Assert.That(index.GetWordsStartWith("cate"), Has.Count.EqualTo(1));
 
-            index.Merge(document, Enumerable.Empty<string>());
+            index.Merge(document, Enumerable.Empty<string>()).Wait();
             foreach (var word in words)
             {
                 Assert.That(index.GetExactWord(word), Is.Empty);
@@ -92,7 +92,7 @@ namespace Primitive.Text.Indexing
             var document = new DocumentInfo("id1", TestDocumentSource.Instance);
             var words = new[] { "Schrœdinger", "Schroedinger", "Schroeder" };
 
-            index.Merge(document, words);
+            index.Merge(document, words).Wait();
             Assert.That(index.GetIndexedWords(), Has.Count.EqualTo(2));
 
             Assert.That(index.GetWordsStartWith("schroe"), Has.Count.EqualTo(2));
@@ -105,13 +105,13 @@ namespace Primitive.Text.Indexing
             IIndex index = indexCreationOptions.CreateIndex();
             var document = new DocumentInfo("id1", TestDocumentSource.Instance);
             var words = new[] { "cat", "category" };
-            index.Merge(document, words);
+            index.Merge(document, words).Wait();
 
             var snapshot = index.Snapshot();
 
             var document2 = new DocumentInfo("id2", TestDocumentSource.Instance);
             var words2 = new[] {"bar"};
-            index.Merge(document2, words2);
+            index.Merge(document2, words2).Wait();
 
             Assert.That(snapshot.GetIndexedWords(), Is.EquivalentTo(words));
             Assert.That(snapshot.GetWordsMatching(_ => true).SelectMany(item => item).Distinct().Single(), Is.EqualTo(document));
@@ -256,7 +256,7 @@ namespace Primitive.Text.Indexing
         {
             var sw = Stopwatch.StartNew();
             Parallel.ForEach(documents, new ParallelOptions {MaxDegreeOfParallelism = 2},
-                item => index.Merge(item.Document, item.IndexWords));
+                item => index.Merge(item.Document, item.IndexWords).Wait());
             sw.Stop();
             Console.WriteLine("Populated index, elapsed {0} ms, total {1} documents processed, total {2} words indexed", sw.ElapsedMilliseconds, documents.Count, index.GetIndexedWords().Count);
         }


### PR DESCRIPTION
- Ensured IndexDocument method is asynchronous regardless of used DocumentSource and TextParser implementations.
- Generalized document text reading, so IDocumentSource can be used for other tasks requiring incremental text reading.
- More wordy and less cryptic way defining isNewDocument.
- An index implementation can specify whether its merges should be parallelized or not.
- RemoveDocumentsMatching: limited number of times the predicate is called to number of indexed documents.
- Remove 'lock(this)' from public surface classes.
